### PR TITLE
Change the Docker container to localhost acc only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     redis:
         image: "redislabs/redismod:latest"
         ports:
-            - 6379:6379
+            - 127.0.0.1:6379:6379
     test:
         build: .
         environment:


### PR DESCRIPTION
-  This creates a small extra level of security not opening your Redis container to the world or relying on previous network firewall rules.